### PR TITLE
Fix missing fold for autumn DST

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 # This workflow will run tests on PRs
 
-name: Tests
+name: Formatting & Tests
 
 on:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # efaciency
 
 ![Tests](https://github.com/github/docs/actions/workflows/test.yml/badge.svg)
-![PyPi](https://img.shields.io/pypi/v/efaciency)
+[![PyPi](https://img.shields.io/pypi/v/efaciency)](https://pypi.org/project/efaciency)
 ![Coverage](https://img.shields.io/badge/coverage-100-green)
 
 A package to simplify working with [EFA](https://en.wikipedia.org/wiki/Electricity_Forward_Agreement) blocks and settlement periods in the GB electricity trading system.
@@ -25,10 +25,10 @@ Get the starting timestamp for a settlement period.
 >>> import efaciency
 
 >>> efaciency.sp.to_ts(settlement_period=4)  # defaults to today as settlement date
-datetime.datetime(2025, 2, 18, 1, 30, tzinfo=<DstTzInfo 'Europe/London' GMT0:00:00 STD>)
+datetime.datetime(2025, 2, 18, 1, 30, tzinfo=zoneinfo.ZoneInfo(key='Europe/London'))
 
 >>> efaciency.sp.to_ts(settlement_period=13, settlement_date=date(2025, 5, 23))
-datetime.datetime(2025, 5, 23, 6, 0, tzinfo=<DstTzInfo 'Europe/London' BST+1:00:00 DST>)
+datetime.datetime(2025, 5, 23, 6, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/London'))
 ```
 
 You can also get the settlement for a given timestamp:
@@ -47,10 +47,10 @@ Get the starting and ending timestamp for an EFA block.
 >>> import efaciency
 
 >>> efaciency.block.to_start_ts(efa_block=3)  # defaults to today as EFA date
-datetime.datetime(2025, 2, 18, 7, 0, tzinfo=<DstTzInfo 'Europe/London' GMT0:00:00 STD>)
+datetime.datetime(2025, 2, 18, 7, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/London'))
 
 >>> efaciency.block.to_start_ts(efa_block=1, efa_date=date(2025, 5, 23))
-datetime.datetime(2025, 5, 22, 23, 0, tzinfo=<DstTzInfo 'Europe/London' BST+1:00:00 DST>)
+datetime.datetime(2025, 5, 22, 23, 0, tzinfo=zoneinfo.ZoneInfo(key='Europe/London'))
 ```
 
 You can also get the EFA block for a given timestamp:

--- a/efaciency/__init__.py
+++ b/efaciency/__init__.py
@@ -2,6 +2,6 @@
 
 from efaciency import block, sp
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 __all__ = ("block", "sp")

--- a/efaciency/sp.py
+++ b/efaciency/sp.py
@@ -38,6 +38,7 @@ def to_ts(settlement_period: int, settlement_date: datetime | None = None) -> da
     """
     settlement_date = settlement_date or date.today()
     offset = timedelta(0)
+    fold = 0
     if settlement_date in dst_transition_dates():
         if settlement_date.month > 6:
             assert 1 <= settlement_period <= 50, (
@@ -45,6 +46,8 @@ def to_ts(settlement_period: int, settlement_date: datetime | None = None) -> da
             )
             if settlement_period >= 5:
                 offset = -timedelta(hours=1)
+            if settlement_period in [5, 6]:
+                fold = 1
         else:
             assert 1 <= settlement_period <= 46, (
                 "SP must be between 1 and 46 (spring DST transition)."
@@ -55,4 +58,4 @@ def to_ts(settlement_period: int, settlement_date: datetime | None = None) -> da
         assert 1 <= settlement_period <= 48, "SP must be between 1 and 48."
     t0 = convert_to_local(datetime.combine(settlement_date, time.min))
     sp_ts = t0 + timedelta(minutes=30 * (settlement_period - 1))
-    return sp_ts + offset
+    return (sp_ts + offset).replace(fold=fold)


### PR DESCRIPTION
Add `.replace(fold=)` with the correct fold value on autumn DST transitions for converting SPs to timestamp.